### PR TITLE
fix: remove extra {{- end -}} statements in catalog Helm template

### DIFF
--- a/src/catalog/chart/templates/_helpers.tpl
+++ b/src/catalog/chart/templates/_helpers.tpl
@@ -138,8 +138,7 @@ app.kubernetes.io/owner: retail-store-sample
 {{- else }}
 {{- .Values.app.persistence.endpoint -}}
 {{- end -}}
-{{- end -}}
-{{- end -}}
+{{- end }}
 
 {{/*
 Generate MySQL root password


### PR DESCRIPTION
- Fixed parsing error in _helpers.tpl at line 122
- Removed duplicate {{- end -}} statements in catalog.mysql.endpoint function
- Resolves ArgoCD deployment failure with 'unexpected {{end}}' error